### PR TITLE
modification to p tags in items

### DIFF
--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -37,7 +37,9 @@ class EADSerializer < ASpaceExport::Serializer
     content = content.gsub("<br>", "<br/>").gsub("</br>", '')
     # lets break the text, if it has linebreaks but no p tags.  
     
-    if allow_p 
+    if allow_p == "neither"
+        content = content
+    elsif allow_p
       content = handle_linebreaks(content) 
     else
       content = strip_p(content)
@@ -348,7 +350,7 @@ class EADSerializer < ASpaceExport::Serializer
           xml.head { sanitize_mixed_content(title, xml, fragments) }  if title
 
           sn['items'].each do |item|
-            xml.item { sanitize_mixed_content(item,xml, fragments)} 
+            xml.item { sanitize_mixed_content(item,xml, fragments, allow_p = "neither")} 
           end
         }
       when 'note_definedlist'


### PR DESCRIPTION
Apparently p tags on the way out of ArchivesSpace are all or nothin' -- either ArchivesSpace strips all p tags, or adds p tags where it thinks there should be p tags. This works for the most part, but we have some p tags inside of items (https://github.com/bentley-historical-library/vandura/blob/master/Real_Masters_all/winchell.xml#L4683) that were initially getting stripped out, invalidating the exported EAD. Setting allow_p to true would insert p tags in a bunch of places in lists/items that would ALSO invalidate the EAD, so I added a third case ("neither") that leaves the content alone. This will require some further testing to ensure that it doesn't cause any other problems, but I don't think it should.