### PR TITLE
Two modifications to index serialization

### DIFF
--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -187,7 +187,7 @@ class EADSerializer < ASpaceExport::Serializer
             end
           end
 
-          if descgrp_add
+          if descgrp_add or data.indexes
             xml.descgrp({'type'=>'add'}) {
               serialize_descgrp_add_notes(data, xml, @fragments,level="resource")
               serialize_indexes(data, xml, @fragments)
@@ -721,7 +721,12 @@ class EADSerializer < ASpaceExport::Serializer
             end
             if (val = item['reference_text'])
               xml.ref(atts) {
-                sanitize_mixed_content( val, xml, fragments)
+                # MODIFICATION: Export indexentry refs in list/item tags for DLXS
+                xml.list({:type=>'simple'}) {
+                  xml.item {
+                    sanitize_mixed_content(val, xml, fragments)
+                  }
+                }
               }
             end
           }

--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -187,7 +187,7 @@ class EADSerializer < ASpaceExport::Serializer
             end
           end
 
-          if descgrp_add or data.indexes
+          if descgrp_add or data.indexes.length > 0
             xml.descgrp({'type'=>'add'}) {
               serialize_descgrp_add_notes(data, xml, @fragments,level="resource")
               serialize_indexes(data, xml, @fragments)


### PR DESCRIPTION
1. Only make a descgrp type="add" if there are notes that belong there OR there are indices. Collections with just an index and no other descgrp type="add" notes were not being serialized properly.
2. Export indexentry/refs with nested list/item tags as they are now to preserve the display in DLXS. The importer strips those lists from refs (which is the right way to do it, I think), so this adds them back in on the way out.