### PR TITLE
Modify bhl ead exporter to be a separate exporter

### DIFF
--- a/backend/controllers/bhl_exports.rb
+++ b/backend/controllers/bhl_exports.rb
@@ -1,3 +1,4 @@
+require_relative "../model/lib/bhl_export"
 class ArchivesSpaceService < Sinatra::Base
 
   include BhlExportHelpers

--- a/backend/controllers/bhl_exports.rb
+++ b/backend/controllers/bhl_exports.rb
@@ -1,0 +1,29 @@
+class ArchivesSpaceService < Sinatra::Base
+
+  include BhlExportHelpers
+
+  Endpoint.get('/repositories/:repo_id/bhl_resource_descriptions/:id.xml')
+    .description("Get an EAD representation of a Resource")
+    .params(["id", :id],
+            ["include_unpublished", BooleanParam,
+             "Include unpublished records", :optional => true],
+            ["include_daos", BooleanParam,
+             "Include digital objects in dao tags", :optional => true],
+            ["numbered_cs", BooleanParam,
+             "Use numbered <c> tags in ead", :optional => true],
+            ["print_pdf", BooleanParam,
+             "Print EAD to pdf", :optional => true],
+            ["repo_id", :repo_id])
+    .permissions([:view_repository])
+    .returns([200, "(:resource)"]) \
+  do
+    redirect to("/repositories/#{params[:repo_id]}/resource_descriptions/#{params[:id]}.pdf?#{ params.map { |k,v| "#{k}=#{v}" }.join("&") }") if params[:print_pdf] 
+    ead_stream = generate_bhl_ead(params[:id],
+                              (params[:include_unpublished] || false),
+                              (params[:include_daos] || false),
+                              (params[:numbered_cs] || false))
+
+    stream_response(ead_stream)
+  end
+
+end

--- a/backend/model/bhl_ead_export_model.rb
+++ b/backend/model/bhl_ead_export_model.rb
@@ -1,5 +1,4 @@
 class BHLEADModel < EADModel
 	model_for :bhl_ead
 
-	super
 end

--- a/backend/model/bhl_ead_export_model.rb
+++ b/backend/model/bhl_ead_export_model.rb
@@ -1,0 +1,5 @@
+class BHLEADModel < EADModel
+	model_for :bhl_ead
+
+	super
+end

--- a/backend/model/bhl_ead_export_model.rb
+++ b/backend/model/bhl_ead_export_model.rb
@@ -1,4 +1,165 @@
 class BHLEADModel < EADModel
 	model_for :bhl_ead
 
+	  include ASpaceExport::ArchivalObjectDescriptionHelpers
+  include ASpaceExport::LazyChildEnumerations
+
+  @data_src = Class.new do
+    def initialize(json)
+      @json = json
+    end
+
+
+    def method_missing(meth)
+      if @json.respond_to?(meth)
+        @json.send(meth)
+      elsif @json.is_a?(Hash) && @json.has_key?("#{meth.to_s}")
+        @json["#{meth.to_s}"]
+      else
+        nil
+      end
+    end
+  end
+
+
+  def self.data_src(json)
+    @data_src.new(json)
+  end
+
+
+  @ao = Class.new do
+    include ASpaceExport::ArchivalObjectDescriptionHelpers
+    include ASpaceExport::LazyChildEnumerations
+
+
+    def initialize(tree, repo_id)
+      @repo_id = repo_id
+      # @tree = tree
+      @children = tree ? tree['children'] : []
+      @child_class = self.class
+      @json = nil
+      RequestContext.open(:repo_id => repo_id) do
+        rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object'], {'ASPACE_REENTRANT' => false})
+        @json = JSONModel::JSONModel(:archival_object).new(rec)
+      end
+    end
+
+
+    def method_missing(meth, *args)
+      if @json.respond_to?(meth)
+        @json.send(meth, *args)
+      else
+        nil
+      end
+    end
+  end
+
+
+  def initialize(obj, opts)
+    @json = obj
+    opts.each do |k, v|
+      self.instance_variable_set("@#{k}", v)
+    end
+    repo_ref = obj.repository['ref']
+    @repo_id = JSONModel::JSONModel(:repository).id_for(repo_ref)
+    @repo = Repository.to_jsonmodel(@repo_id)
+    @children = @json.tree['_resolved']['children']
+    @child_class = self.class.instance_variable_get(:@ao)
+  end
+
+
+  def self.from_resource(obj, opts)
+    self.new(obj, opts)
+  end
+
+
+  def method_missing(meth)
+    if self.instance_variable_get("@#{meth.to_s}")
+      self.instance_variable_get("@#{meth.to_s}")
+    elsif @json.respond_to?(meth)
+      @json.send(meth)
+    else
+      nil
+    end
+  end
+
+
+  def include_unpublished?
+    @include_unpublished
+  end
+
+
+  def use_numbered_c_tags?
+    @use_numbered_c_tags
+  end
+
+
+  def mainagencycode
+    @mainagencycode ||= repo.country && repo.org_code ? [repo.country, repo.org_code].join('-') : nil
+    @mainagencycode
+  end
+
+
+  def agent_representation
+    return false unless @repo['agent_representation_id']
+
+    agent_id = @repo['agent_representation_id']
+    json = AgentCorporateEntity.to_jsonmodel(agent_id)
+
+    json
+  end
+
+
+  def addresslines
+    agent = self.agent_representation
+    return [] unless agent && agent.agent_contacts[0]
+
+    contact = agent.agent_contacts[0]
+
+    data = []
+    (1..3).each do |i|
+      data << contact["address_#{i}"]
+    end
+
+    line = ""
+    line += %w(city region).map{|k| contact[k] }.compact.join(', ')
+    line += " #{contact['post_code']}"
+    line.strip!
+
+    data <<  line unless line.empty?
+
+    %w(telephone email).each do |property|
+      data << contact[property]
+    end
+
+    data.compact!
+
+    data
+  end
+
+
+  def descrules
+    return nil unless @descrules || self.finding_aid_description_rules
+    @descrules ||= I18n.t("enumerations.resource_finding_aid_description_rules.#{self.finding_aid_description_rules}", :default => self.finding_aid_description_rules)
+    @descrules
+  end
+
+
+  def instances_with_containers
+    self.instances.select{|inst| inst['container']}.compact
+  end
+
+
+  def creators_and_sources
+    self.linked_agents.select{|link| ['creator', 'source'].include?(link['role']) }
+  end
+
+
+  def digital_objects
+    if @include_daos
+      self.instances.select{|inst| inst['digital_object']}.compact.map{|inst| inst['digital_object']['_resolved'] }.compact
+    else
+      []
+    end
+  end
 end

--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -362,7 +362,7 @@ class BHLEADSerializer < ASpaceExport::Serializer
                     when 'agent_corporate_entity'; 'corpname'
                     end
         xml.origination(:label => role) {
-         atts = {:role => relator, :source => source, :rules => rules, :authfilenumber => authfilenumber}
+         atts = {:role => relator, :source => source, :rules => rules}
          atts.reject! {|k, v| v.nil?}
 
           xml.send(node_name, atts) {

--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -5,8 +5,22 @@ require_relative 'lib/descgrp_types'
 require_relative 'lib/resolve_classifications'
 require_relative 'lib/singularize_extents'
 
-class EADSerializer < ASpaceExport::Serializer
-  serializer_for :ead
+class BHLEADSerializer < ASpaceExport::Serializer
+  serializer_for :bhl_ead
+
+  # Allow plugins to hook in to record processing by providing their own
+  # serialization step (a class with a 'call' method accepting the arguments
+  # defined in `run_serialize_step`.
+  def self.add_serialize_step(serialize_step)
+    @extra_serialize_steps ||= []
+    @extra_serialize_steps << serialize_step
+  end
+
+  def self.run_serialize_step(data, xml, fragments, context)
+    Array(@extra_serialize_steps).each do |step|
+      step.new.call(data, xml, fragments, context)
+    end
+  end
 
 
   def prefix_id(id)
@@ -153,6 +167,8 @@ class EADSerializer < ASpaceExport::Serializer
               #serialize_container(instance, xml, @fragments)
             #end
 
+            EADSerializer.run_serialize_step(data, xml, @fragments, :did)
+
           }# </did>
             
           data.digital_objects.each do |dob|
@@ -182,6 +198,8 @@ class EADSerializer < ASpaceExport::Serializer
 
 
           serialize_controlaccess(data, xml, @fragments)
+
+          EADSerializer.run_serialize_step(data, xml, @fragments, :archdesc)
 
           xml.dsc({'type'=>'combined'}) {
 
@@ -275,6 +293,8 @@ class EADSerializer < ASpaceExport::Serializer
         # MODIFICATION: Set serialize_x_notes level to "child" so that extptrs are not added to accessrestrict or processinfo
         serialize_did_notes(data, xml, fragments, level="child")
 
+        EADSerializer.run_serialize_step(data, xml, fragments, :did)
+
         # TODO: Clean this up more; there's probably a better way to do this.
         # For whatever reason, the old ead_containers method was not working
         # on archival_objects (see migrations/models/ead.rb).
@@ -308,6 +328,8 @@ class EADSerializer < ASpaceExport::Serializer
 
       serialize_controlaccess(data, xml, fragments)
 
+      EADSerializer.run_serialize_step(data, xml, fragments, :archdesc)
+
       data.children_indexes.each do |i|
         xml.text(
                  @stream_handler.buffer {|xml, new_fragments|
@@ -340,7 +362,7 @@ class EADSerializer < ASpaceExport::Serializer
                     when 'agent_corporate_entity'; 'corpname'
                     end
         xml.origination(:label => role) {
-         atts = {:role => relator, :source => source, :rules => rules}
+         atts = {:role => relator, :source => source, :rules => rules, :authfilenumber => authfilenumber}
          atts.reject! {|k, v| v.nil?}
 
           xml.send(node_name, atts) {

--- a/backend/model/lib/bhl_export.rb
+++ b/backend/model/lib/bhl_export.rb
@@ -1,0 +1,20 @@
+module BhlExportHelpers
+
+  include ExportHelpers
+  include ASpaceExport
+
+  ASpaceExport::init
+
+  def generate_bhl_ead(id, include_unpublished, include_daos, use_numbered_c_tags)
+    obj = resolve_references(Resource.to_jsonmodel(i
+      :include_unpublished => include_unpublished,
+      :include_daos => include_daos,
+      :use_numbered_c_tags => use_numbered_c_tagsd), ['repository', 'linked_agents', 'subjects', 'tree', 'digital_object'])
+    opts = {
+    }
+
+    ead = ASpaceExport.model(:bhl_ead).from_resource(JSONModel(:resource).new(obj), opts)
+    ASpaceExport::stream(ead)
+  end
+
+end

--- a/backend/model/lib/bhl_export.rb
+++ b/backend/model/lib/bhl_export.rb
@@ -6,11 +6,11 @@ module BhlExportHelpers
   ASpaceExport::init
 
   def generate_bhl_ead(id, include_unpublished, include_daos, use_numbered_c_tags)
-    obj = resolve_references(Resource.to_jsonmodel(i
+    obj = resolve_references(Resource.to_jsonmodel(id), ['repository', 'linked_agents', 'subjects', 'tree', 'digital_object'])
+    opts = {
       :include_unpublished => include_unpublished,
       :include_daos => include_daos,
-      :use_numbered_c_tags => use_numbered_c_tagsd), ['repository', 'linked_agents', 'subjects', 'tree', 'digital_object'])
-    opts = {
+      :use_numbered_c_tags => use_numbered_c_tags
     }
 
     ead = ASpaceExport.model(:bhl_ead).from_resource(JSONModel(:resource).new(obj), opts)

--- a/frontend/controllers/bhlexports_controller.rb
+++ b/frontend/controllers/bhlexports_controller.rb
@@ -1,4 +1,4 @@
-class BhlExportsController < ApplicationController
+class BhlexportsController < ApplicationController
 
   set_access_control  "view_repository" => [:download_bhl_ead]
 
@@ -6,8 +6,9 @@ class BhlExportsController < ApplicationController
 
   def download_bhl_ead
     url = "/repositories/#{JSONModel::repository}/bhl_resource_descriptions/#{params[:id]}.xml"
+    metadata_url = "/repositories/#{JSONModel::repository}/resource_descriptions/#{params[:id]}.xml"
 
-    download_export(url,
+    download_bhl_export(url, metadata_url,
                     :include_unpublished => (params[:include_unpublished] ? params[:include_unpublished] : false),
                     :print_pdf => (params[:print_pdf] ? params[:print_pdf] : false),
                     :include_daos => (params[:include_daos] ? params[:include_daos] : false),
@@ -17,9 +18,9 @@ class BhlExportsController < ApplicationController
 
   private
 
-  def download_export(request_uri, params = {})
+  def download_bhl_export(request_uri, metadata_uri, params = {})
 
-    meta = JSONModel::HTTP::get_json("#{request_uri}/metadata")
+    meta = JSONModel::HTTP::get_json("#{metadata_uri}/metadata")
 
     respond_to do |format|
       format.html {

--- a/frontend/controllers/bhlexports_controller.rb
+++ b/frontend/controllers/bhlexports_controller.rb
@@ -1,0 +1,39 @@
+class BhlExportsController < ApplicationController
+
+  set_access_control  "view_repository" => [:download_bhl_ead]
+
+  include ExportHelper
+
+  def download_bhl_ead
+    url = "/repositories/#{JSONModel::repository}/bhl_resource_descriptions/#{params[:id]}.xml"
+
+    download_export(url,
+                    :include_unpublished => (params[:include_unpublished] ? params[:include_unpublished] : false),
+                    :print_pdf => (params[:print_pdf] ? params[:print_pdf] : false),
+                    :include_daos => (params[:include_daos] ? params[:include_daos] : false),
+                    :numbered_cs => (params[:numbered_cs] ? params[:numbered_cs] : false))
+  end
+
+
+  private
+
+  def download_export(request_uri, params = {})
+
+    meta = JSONModel::HTTP::get_json("#{request_uri}/metadata")
+
+    respond_to do |format|
+      format.html {
+        self.response.headers["Content-Type"] ||= meta['mimetype']
+        self.response.headers["Content-Disposition"] = "attachment; filename=#{meta['filename']}"
+        self.response.headers['Last-Modified'] = Time.now.ctime.to_s
+
+        self.response_body = Enumerator.new do |y|
+          xml_response(request_uri, params) do |chunk, percent|
+            y << chunk if !chunk.blank?
+          end
+        end
+      }
+    end
+  end
+
+end

--- a/frontend/plugin_init.rb
+++ b/frontend/plugin_init.rb
@@ -1,0 +1,2 @@
+my_routes = [File.join(File.dirname(__FILE__), "routes.rb")]
+ArchivesSpace::Application.config.paths['config/routes'].concat(my_routes)

--- a/frontend/routes.rb
+++ b/frontend/routes.rb
@@ -1,0 +1,9 @@
+ArchivesSpace::Application.routes.draw do
+
+  [AppConfig[:frontend_proxy_prefix], AppConfig[:frontend_prefix]].uniq.each do |prefix|
+
+    scope prefix do
+      match 'resources/:id/download_bhl_ead' => 'bhlexports#download_bhl_ead', :via => [:get]
+    end
+  end
+end

--- a/frontend/views/resources/_toolbar.html.erb
+++ b/frontend/views/resources/_toolbar.html.erb
@@ -1,0 +1,37 @@
+<% if user_can?('update_resource_record') %>
+
+  <% unless content_for?(:exports) %>
+    <% content_for :exports do %>
+      <li class="dropdown-submenu" id="download-ead-dropdown" data-download-ead-url="<%= url_for(:controller => :bhlexports, :action => :download_bhl_ead, :id => @resource.id, :include_unpublished => "${include_unpublished}", :include_daos => "${include_daos}", :numbered_cs => "${numbered_cs}", :print_pdf => "${print_pdf}" )%>">
+        <a href="#" data-toggle="dropdown" class="menu-with-options download-ead-action" title="<%= I18n.t("actions.export_ead") %>"><%= I18n.t("actions.export_ead") %></a>        
+        <div class="dropdown-menu" id="form_download_ead">
+          <fieldset>
+            <input type="hidden" name="id", value="<%= @resource.id %>" />
+            <label class="checkbox" for="include-unpublished">
+              <input type="checkbox" id="include-unpublished" name="include_unpublished" checked="checked"/>
+              <%= I18n.t("export_options.include_unpublished") %>&#160;
+            </label>
+            <label class="checkbox" for="include-daos">
+              <input type="checkbox" id="include-daos" name="include_daos" checked="checked"/>
+              <%= I18n.t("export_options.include_daos") %>&#160;
+            </label>
+            <label class="checkbox" for="numbered-cs">
+              <input type="checkbox" id="numbered-cs" name="numbered_cs" />
+              <%= I18n.t("export_options.numbered_cs") %>&#160;
+            </label>
+          </fieldset>
+        </div>
+      </li>
+      <li><%= link_to I18n.t("actions.export_marc"), {:controller => :exports, :action => :download_marc, :id => @resource.id} %></li>
+      <li><%= link_to I18n.t("actions.container_labels"), {:controller => :exports, :action => :container_labels, :id => @resource.id} %></li>
+      <li><%= link_to I18n.t("actions.print_to_pdf"), {:controller => :jobs,  :action => :new}, :target => "_blank" %></li>
+    <% end %>
+  <% end %>
+
+  <%= render_aspace_partial(:partial => '/shared/resource_toolbar',
+             :locals => {
+              :record_type => 'resource',
+              :record => @resource,
+             })
+  %>
+<% end %>


### PR DESCRIPTION
Modified the plugin so that the bhl_ead_exporter is a separate exporter, not just a replacement for the stock ead exporter.

This ensures that other processes that rely on the stock ead exporter, such as the print to pdf function, will still work. The way this was written before meant that our modifications to the exporter overrode the stock aspace exporter functionality, which caused some problems.

This update also includes a new API endpoint for the bhl ead exporter