### PR TITLE
minor bug fixes + beginning of adding links to abstracts

### DIFF
--- a/backend/model/bhl_digitization_export_model.rb
+++ b/backend/model/bhl_digitization_export_model.rb
@@ -39,7 +39,7 @@ class BHLDigitizationModel < EADModel
       @child_class = self.class
       @json = nil
       RequestContext.open(:repo_id => repo_id) do
-        rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object'], {'ASPACE_REENTRANT' => false})
+        rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object'])
         @json = JSONModel::JSONModel(:archival_object).new(rec)
       end
     end

--- a/backend/model/bhl_ead_export_model.rb
+++ b/backend/model/bhl_ead_export_model.rb
@@ -39,7 +39,7 @@ class BHLEADModel < EADModel
       @child_class = self.class
       @json = nil
       RequestContext.open(:repo_id => repo_id) do
-        rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object'], {'ASPACE_REENTRANT' => false})
+        rec = URIResolver.resolve_references(ArchivalObject.to_jsonmodel(tree['id']), ['subjects', 'linked_agents', 'digital_object'])
         @json = JSONModel::JSONModel(:archival_object).new(rec)
       end
     end

--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -662,16 +662,13 @@ class BHLEADSerializer < ASpaceExport::Serializer
     atts['title'] = digital_object['title'] if digital_object['title']
         
     #MODIFICATION: Insert original note into <daodesc> instead of the default title
-    daodesc_content = nil
+    daodesc_content = "[access item]"
     
     digital_object_notes.each do |note|
         if note['type'] == 'note'
-            daodesc_content = note['content'][0]
+            daodesc_content = "[#{note['content'][0]}]"
         end
-    end
-
-    daodesc_content = "[#{daodesc_content}]" || "[access item]"
-    
+    end    
     
     if file_versions.empty?
       atts['href'] = digital_object['digital_object_id']

--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -681,7 +681,7 @@ class BHLEADSerializer < ASpaceExport::Serializer
       file_versions.each do |file_version|
         atts['href'] = file_version['file_uri'] || digital_object['digital_object_id']
         # MODIFICATION: downcase xlink_actuate_attribute
-        atts['actuate'] = file_version['xlink_actuate_attribute'].downcase || 'onrequest'
+        atts['actuate'] = file_version['xlink_actuate_attribute'] ? file_version['xlink_actuate_attribute'].downcase : 'onrequest'
         atts['show'] = file_version['xlink_show_attribute'] || 'new'
         xml.dao(atts) {
           xml.daodesc { sanitize_mixed_content(daodesc_content, xml, fragments, true) } if content


### PR DESCRIPTION
1. added some code that was added to the stock ASpace exporter to handle some ampersand issues
2. fixed a bug in daodesc default text
3. got rid of some legacy parameters that ASpace doesn't use anymore and that were silently clogging up the logs
4. adding the beginning of a proof of concept for exporting links in collection level abstracts (NOTE: this is not finished/is actually sort of broken... potentially destructive lines are commented out for now)