### PR TITLE
add aspace escape_content code and check for preescaped characters

### DIFF
--- a/backend/model/bhl_ead_exporter.rb
+++ b/backend/model/bhl_ead_exporter.rb
@@ -41,7 +41,37 @@ class BHLEADSerializer < ASpaceExport::Serializer
     ignore = Regexp.union(ignore) 
     # the "wrap" is just to ensure that there is a psuedo root element to eliminate a "false" error
     Nokogiri::XML("<wrap>#{content}</wrap>").errors.reject { |e| e.message =~ ignore  }
-  end 
+  end
+
+  # ANW-716: We may have content with a mix of loose '&' chars that need to be escaped, along with pre-escaped HTML entities
+  # Example:
+  # c                 => "This is the &lt; test & for the <title>Sanford &amp; Son</title>
+  # escape_content(c) => "This is the &lt; test &amp; for the <title>Sanford &amp; Son</title>
+  # we want to leave the pre-escaped entities alone, and escape the loose & chars
+
+  def escape_content(content)
+    # first, find any pre-escaped entities and "mark" them by replacing & with @@
+    # so something like &lt; becomes @@lt;
+    # and &#1234 becomes @@#1234
+
+    content.gsub!(/&\w+;/) {|t| t.gsub('&', '@@')}
+    content.gsub!(/&#\d{4}/) {|t| t.gsub('&', '@@')}
+    content.gsub!(/&#\d{3}/) {|t| t.gsub('&', '@@')}
+
+    # now we know that all & characters remaining are not part of some pre-escaped entity, and we can escape them safely
+    content.gsub!('&', '&amp;')
+
+    # 'unmark' our pre-escaped entities
+    content.gsub!(/@@\w+;/) {|t| t.gsub('@@', '&')}
+    content.gsub!(/@@#\d{4}/) {|t| t.gsub('@@', '&')}
+    content.gsub!(/@@#\d{3}/) {|t| t.gsub('@@', '&')}
+
+    # only allow predefined XML entities, otherwise convert ampersand so XML will validate
+    valid_entities = ['&quot;', '&amp;', '&apos;', '&lt;', '&gt;']
+    content.gsub!(/&\w+;/) { |t| valid_entities.include?(t) ? t : t.gsub(/&/,'&amp;') }
+
+    content
+  end
 
 
   def handle_linebreaks(content)
@@ -52,25 +82,19 @@ class BHLEADSerializer < ASpaceExport::Serializer
     original_content = content
     blocks = content.split("\n\n").select { |b| !b.strip.empty? }
     if blocks.length > 1
-      content = blocks.inject("") { |c,n| c << "<p>#{n.chomp}</p>"  }
+      content = blocks.inject("") { |c,n| c << "<p>#{escape_content(n.chomp)}</p>"  }
     else
-      content = "<p>#{content.strip}</p>"
+      content = "<p>#{escape_content(content.strip)}</p>"
     end
 
-    # first lets see if there are any &
-    # note if there's a &somewordwithnospace , the error is EntityRef and wont
-    # be fixed here...
-    if xml_errors(content).any? { |e| e.message.include?("The entity name must immediately follow the '&' in the entity reference.") }
-      content.gsub!("& ", "&amp; ")
-    end
-
-    # in some cases adding p tags can create invalid markup with mixed content
     # just return the original content if there's still problems
     xml_errors(content).any? ? original_content : content
   end
 
   def strip_p(content)
-    content.gsub("<p>", "").gsub("</p>", "").gsub("<p/>", '')
+    content = content.gsub("<p>", "").gsub("</p>", "").gsub("<p/>", '')
+    content = escape_content(content.strip)
+    content
   end
 
   def remove_smart_quotes(content)
@@ -99,8 +123,8 @@ class BHLEADSerializer < ASpaceExport::Serializer
     end
     
     begin 
-      if ASpaceExport::Utils.has_html?(content)
-         context.text( fragments << content )
+      if ASpaceExport::Utils.has_html?(content) or content =~ /&#\d{3,4};/
+         context.text ( fragments << content )
       else
         context.text content.gsub("&amp;", "&") #thanks, Nokogiri
       end


### PR DESCRIPTION
This brings over the escape_content function added in ArchivesSpace v2.5.2 and also checks for pre-escaped numeric entities. This primarily came up from a finding aid that had a registered trademark symbol (&#174;) throughout that was being exported as both &#174; and &amp;#174; due to Nokogiri weirdness.